### PR TITLE
Fix Connections legend toggle + unified scientific UI redesign

### DIFF
--- a/src/lib/cpd/plot.ts
+++ b/src/lib/cpd/plot.ts
@@ -169,6 +169,7 @@ export function createTraces(parsedData: ParsedCPDData, options: PlotOptions): D
           line: { color: color, width: lineWidth },
           hoverinfo: 'skip',
           showlegend: true,
+          legendgroup: 'connections',
           name: lineNameDisplay
         } as Data)
 
@@ -176,9 +177,10 @@ export function createTraces(parsedData: ParsedCPDData, options: PlotOptions): D
           x: hoverX,
           y: hoverY,
           mode: 'markers',
-          marker: { size: 1, opacity: 0 },
+          marker: { size: 10, color: 'rgba(0,0,0,0)' },
           text: hoverText,
           hoverinfo: 'text',
+          legendgroup: 'connections',
           showlegend: false
         } as Data)
       }
@@ -202,7 +204,11 @@ export function createTraces(parsedData: ParsedCPDData, options: PlotOptions): D
       const hoverY: number[] = []
       const hoverText: string[] = []
 
-      for (const [weight, group] of weightGroups) {
+      const sortedWeights = Array.from(weightGroups.keys()).sort((a, b) => a - b)
+      let firstTrace = true
+
+      for (const weight of sortedWeights) {
+        const group = weightGroups.get(weight)!
         const normalizedWeight = weightRange > 0 ? (weight - minWeight) / weightRange : 0.5
         const lineColor = getSchemeColor(normalizedWeight, schemeName)
         const colorWithOpacity = lineColor.replace('rgb', 'rgba').replace(')', `, ${lineOpacity})`)
@@ -230,19 +236,22 @@ export function createTraces(parsedData: ParsedCPDData, options: PlotOptions): D
           mode: 'lines',
           line: { color: colorWithOpacity, width: lineWidth },
           hoverinfo: 'skip',
-          showlegend: false
+          legendgroup: 'connections',
+          showlegend: firstTrace,
+          name: firstTrace ? lineNameDisplay : undefined
         } as Data)
+        firstTrace = false
       }
 
       traces.push({
         x: hoverX,
         y: hoverY,
         mode: 'markers',
-        marker: { size: 1, opacity: 0 },
+        marker: { size: 10, color: 'rgba(0,0,0,0)' },
         text: hoverText,
         hoverinfo: 'text',
-        showlegend: true,
-        name: lineNameDisplay
+        legendgroup: 'connections',
+        showlegend: false
       } as Data)
     }
   }
@@ -372,6 +381,7 @@ export function createTraces(parsedData: ParsedCPDData, options: PlotOptions): D
           }
         },
         hoverinfo: 'skip',
+        legendgroup: 'connections',
         showlegend: false
       } as Data)
     }

--- a/src/pages/CPDViewerPage.tsx
+++ b/src/pages/CPDViewerPage.tsx
@@ -64,12 +64,12 @@ export default function CPDViewerPage() {
   const [lowerLifetimeMax, setLowerLifetimeMax] = useState(0)
 
   const [lineColorMode, setLineColorMode] = useState<'single' | 'scale'>('scale')
-  const [lineSingleColor, setLineSingleColor] = useState('#888888')
-  const [lineColorscale, setLineColorscale] = useState<ColorscaleName>('YlOrRd')
+  const [lineSingleColor, setLineSingleColor] = useState('#9ca3af')
+  const [lineColorscale, setLineColorscale] = useState<ColorscaleName>('Greys')
   const [lineFilterMin, setLineFilterMin] = useState<string>('')
   const [lineFilterMax, setLineFilterMax] = useState<string>('')
-  const [lineOpacity, setLineOpacity] = useState(0.5)
-  const [lineWidth, setLineWidth] = useState(1)
+  const [lineOpacity, setLineOpacity] = useState(0.6)
+  const [lineWidth, setLineWidth] = useState(0.8)
 
   const getFilter = useCallback((minStr: string, maxStr: string): Filter => {
     const min = minStr === '' ? null : parseFloat(minStr)


### PR DESCRIPTION
## Summary

Two related changes on this branch:

### 1. Fix the Connections legend in the CPD viewer
The "Connections" entry was missing from the legend and there was no way to show/hide the connection lines. In the default "scale" color mode each line was a separate `showlegend: false` trace and the legend was driven by a hidden zero-size marker. All connection traces (lines, hover markers, colorbar carrier) are now grouped under a shared `legendgroup`, with the first line trace surfaced as the legend entry — clicking "Connections" now toggles every connection line and its colorbar. Restored the original `Greys` / `0.8` / `0.6` connection defaults so the lines stay visually distinct from the heat-colored points.

### 2. Unified scientific UI redesign with light/dark mode
- Cohesive design system on semantic theme tokens; full dark mode (pre-paint inline script, persisted toggle).
- Shared `SiteHeader` (nav + Code/Paper + theme toggle) and `SiteFooter` across pages.
- Reworked HomePage, CoursesPage, and the CPD Viewer with a restrained, modern scientific look.
- Scientific figures (Plotly plot, lattice SVGs, data grid) sit on a constant light "paper" surface in both themes so they stay legible — D3/Plotly rendering logic untouched.

## Test plan

- [x] `tsc -b`, `eslint` (0 errors), and production `vite build` all pass
- [x] Connections legend appears with a line glyph and toggles all lines on/off (scale + single modes)
- [x] All CPD viewer controls (filters, width, opacity, name, color, colorscale) still update the plot
- [x] Home / Courses (table + gallery) / CPD Viewer verified in both light and dark
- [x] Courses grid + gallery filtering and Plotly export preserved

https://claude.ai/code/session_01Ss3QHhdWWXGJEQVxvWvZLq