### PR TITLE
Unified scientific UI redesign with light/dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,18 @@
     <title>Refinement of Interval Approximations for Fully Commutative Quivers</title>
     <link href="https://fonts.googleapis.com/css?family=Google+Sans|Noto+Sans|Castoro" rel="stylesheet" />
     <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('theme');
+          if (t !== 'light' && t !== 'dark') {
+            t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          if (t === 'dark') document.documentElement.classList.add('dark');
+          document.documentElement.style.colorScheme = t;
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,16 @@
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-border bg-background">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6">
+        <p className="text-sm text-muted-foreground">
+          Ladder Invariants Project &mdash; Refinement of Interval Approximations for Fully
+          Commutative Quivers.
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground/80">
+          Hiraoka, Nakashima, Obayashi, Xu. Published in Japan Journal of Industrial and Applied
+          Mathematics.
+        </p>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,71 @@
+import { Link, useLocation } from 'react-router-dom'
+import { Github, FileText } from 'lucide-react'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { cn } from '@/lib/utils'
+
+const navLinks = [
+  { to: '/', label: 'Overview' },
+  { to: '/courses', label: 'Courses' },
+  { to: '/cpd-viewer', label: 'CPD Viewer' },
+]
+
+export function SiteHeader() {
+  const { pathname } = useLocation()
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur supports-[backdrop-filter]:bg-background/70">
+      <div className="mx-auto flex h-16 max-w-6xl items-center gap-4 px-4 sm:px-6">
+        <Link to="/" className="flex items-center gap-2.5 shrink-0">
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground font-bold">
+            Λ
+          </span>
+          <span className="hidden font-semibold tracking-tight text-foreground sm:inline">
+            Ladder Invariants
+          </span>
+        </Link>
+
+        <nav className="ml-2 flex items-center gap-1">
+          {navLinks.map((link) => {
+            const active = pathname === link.to
+            return (
+              <Link
+                key={link.to}
+                to={link.to}
+                className={cn(
+                  'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                  active
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-muted-foreground hover:bg-accent/60 hover:text-foreground'
+                )}
+              >
+                {link.label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="ml-auto flex items-center gap-2">
+          <a
+            href="https://github.com/CommutativeGrids/commutazzio"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden h-9 items-center gap-1.5 rounded-lg px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:inline-flex"
+          >
+            <Github className="h-4 w-4" />
+            Code
+          </a>
+          <a
+            href="https://link.springer.com/article/10.1007/s13160-025-00739-w"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden h-9 items-center gap-1.5 rounded-lg px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:inline-flex"
+          >
+            <FileText className="h-4 w-4" />
+            Paper
+          </a>
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,25 @@
+import { Moon, Sun } from 'lucide-react'
+import { useTheme } from '@/lib/theme'
+import { cn } from '@/lib/utils'
+
+export function ThemeToggle({ className }: { className?: string }) {
+  const { theme, toggleTheme } = useTheme()
+  const isDark = theme === 'dark'
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Light mode' : 'Dark mode'}
+      className={cn(
+        'inline-flex h-9 w-9 items-center justify-center rounded-lg border border-border',
+        'bg-card text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        className
+      )}
+    >
+      {isDark ? <Moon className="h-[18px] w-[18px]" /> : <Sun className="h-[18px] w-[18px]" />}
+    </button>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,26 +4,48 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --background: 210 40% 98%;
+    --foreground: 222 47% 11%;
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
+    --popover-foreground: 222 47% 11%;
+    --primary: 221 83% 53%;
     --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
+    --secondary: 210 40% 94%;
+    --secondary-foreground: 222 47% 11%;
+    --muted: 210 40% 95%;
+    --muted-foreground: 215 16% 42%;
+    --accent: 221 83% 96%;
+    --accent-foreground: 221 83% 33%;
+    --destructive: 0 72% 51%;
     --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
-    --radius: 0.5rem;
+    --border: 214 32% 89%;
+    --input: 214 32% 89%;
+    --ring: 221 83% 53%;
+    --radius: 0.625rem;
+  }
+
+  .dark {
+    --background: 222 47% 7%;
+    --foreground: 210 40% 96%;
+    --card: 222 40% 10%;
+    --card-foreground: 210 40% 96%;
+    --popover: 222 40% 10%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 222 47% 9%;
+    --secondary: 217 33% 16%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 217 33% 15%;
+    --muted-foreground: 215 20% 62%;
+    --accent: 217 40% 18%;
+    --accent-foreground: 210 40% 96%;
+    --destructive: 0 63% 45%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217 33% 20%;
+    --input: 217 33% 22%;
+    --ring: 217 91% 60%;
   }
 }
 
@@ -31,21 +53,60 @@
   * {
     @apply border-border;
   }
+  html {
+    scroll-behavior: smooth;
+  }
   body {
-    @apply bg-background text-foreground font-sans;
+    @apply bg-background text-foreground font-sans antialiased;
+  }
+}
+
+@layer components {
+  /* Scientific figures stay on a constant light "paper" surface in both
+     themes so plots and SVG diagrams remain legible. */
+  .figure-surface {
+    background-color: #ffffff;
+    color: #0f172a;
+    border: 1px solid rgb(226 232 240);
+  }
+  .dark .figure-surface {
+    border-color: rgb(51 65 85);
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.4);
+  }
+
+  .section-eyebrow {
+    @apply inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-primary;
+  }
+
+  /* Control-panel group header used in the CPD viewer side panel. */
+  .panel-section-title {
+    @apply flex items-center gap-2.5 text-[11px] font-bold uppercase tracking-[0.14em]
+           text-primary py-3 mb-4 border-b border-border;
+  }
+
+  .panel-label {
+    @apply text-[11px] uppercase tracking-wide text-muted-foreground;
+  }
+
+  .panel-input {
+    @apply w-full border border-input bg-background text-foreground rounded-md text-sm
+           px-3 transition-colors placeholder:text-muted-foreground/50
+           focus:outline-none focus:ring-2 focus:ring-ring focus:border-ring;
   }
 }
 
 .publication-title {
-  font-family: 'Google Sans', sans-serif;
+  font-family: 'Google Sans', 'Noto Sans', sans-serif;
+  letter-spacing: -0.02em;
 }
 
 .publication-authors {
-  font-family: 'Google Sans', sans-serif;
+  font-family: 'Google Sans', 'Noto Sans', sans-serif;
 }
 
 .publication-authors a {
-  color: hsl(204, 86%, 53%);
+  @apply text-primary;
+  transition: color 0.15s ease;
 }
 
 .publication-authors a:hover {
@@ -56,14 +117,8 @@
   display: inline;
 }
 
-.gallery-item {
-  width: 440px;
-  height: 180px;
-  border: 2px solid #E5E7EB;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
+.prose-abstract {
+  font-family: 'Castoro', Georgia, serif;
 }
 
 .arrowHead {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+const STORAGE_KEY = 'theme'
+
+export function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light'
+  const stored = localStorage.getItem(STORAGE_KEY)
+  if (stored === 'light' || stored === 'dark') return stored
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement
+  root.classList.toggle('dark', theme === 'dark')
+  root.style.colorScheme = theme
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme)
+
+  useEffect(() => {
+    applyTheme(theme)
+    localStorage.setItem(STORAGE_KEY, theme)
+  }, [theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((t) => (t === 'dark' ? 'light' : 'dark'))
+  }, [])
+
+  return { theme, toggleTheme }
+}

--- a/src/pages/CPDViewerPage.tsx
+++ b/src/pages/CPDViewerPage.tsx
@@ -5,6 +5,7 @@ import Plot from 'react-plotly.js'
 import Plotly from 'plotly.js-dist-min'
 import { DATA_SI100, DATA_O50, type CPDDataset } from '../data/cpd-data'
 import { parseData, type Filter } from '../lib/cpd/parse'
+import { ThemeToggle } from '@/components/ui/theme-toggle'
 import {
   createTraces,
   createLayout,
@@ -156,12 +157,12 @@ export default function CPDViewerPage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <header className="h-20 bg-white border-b border-gray-200 px-6 flex items-center fixed top-0 left-0 right-0 z-[300]">
+    <div className="min-h-screen bg-background">
+      <header className="h-20 bg-card border-b border-border px-6 flex items-center fixed top-0 left-0 right-0 z-[300]">
         <button
           onClick={() => setMenuOpen(!menuOpen)}
           className={`w-10 h-10 rounded-lg flex items-center justify-center transition-all ${
-            menuOpen ? 'bg-blue-600 text-white' : 'bg-transparent text-gray-400 hover:bg-gray-100'
+            menuOpen ? 'bg-primary text-primary-foreground' : 'bg-transparent text-muted-foreground hover:bg-accent'
           }`}
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -169,43 +170,46 @@ export default function CPDViewerPage() {
           </svg>
         </button>
         <div className="flex items-center gap-4 flex-1 ml-4">
-          <h1 className="text-lg font-semibold text-gray-800">Connected Persistence Diagram Viewer</h1>
-          <span className="text-gray-400">|</span>
+          <h1 className="text-lg font-semibold text-foreground">Connected Persistence Diagram Viewer</h1>
+          <span className="text-border">|</span>
           <div className="flex items-center gap-2">
-            <label className="text-sm text-gray-600 font-medium">Dataset:</label>
+            <label className="text-sm text-muted-foreground font-medium">Dataset:</label>
             <select
               value={dataset}
               onChange={(e) => setDataset(e.target.value)}
-              className="h-9 px-3 border border-gray-200 rounded text-sm bg-white"
+              className="panel-input h-9 w-auto"
             >
               <option value="SI100">SiO₂ - Si 100% deleted</option>
               <option value="O50">SiO₂ - O 50% deleted</option>
             </select>
           </div>
         </div>
-        <Link to="/" className="p-2 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
-          <Home className="h-5 w-5 text-gray-600" />
-        </Link>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+          <Link to="/" className="inline-flex h-9 w-9 items-center justify-center bg-card border border-border rounded-lg hover:bg-accent hover:text-accent-foreground transition-colors">
+            <Home className="h-5 w-5 text-muted-foreground" />
+          </Link>
+        </div>
       </header>
 
       <div className="flex pt-20">
         <div
-          className={`fixed left-0 top-20 w-[340px] h-[calc(100vh-80px)] bg-white border-r border-gray-200 shadow-md z-50 overflow-y-auto transition-transform duration-300 ${
+          className={`fixed left-0 top-20 w-[340px] h-[calc(100vh-80px)] bg-card border-r border-border shadow-md z-50 overflow-y-auto transition-transform duration-300 ${
             menuOpen ? 'translate-x-0' : '-translate-x-full'
           }`}
         >
           <div className="p-5">
             {/* Layout Section */}
             <div className="menu-section mb-6">
-              <div className="flex items-center gap-3 text-xs font-bold text-white -mx-5 mb-5 py-3.5 px-5 pl-[18px] bg-gradient-to-r from-blue-600 to-blue-500 uppercase tracking-wider shadow-sm">
-                <svg className="w-4 h-4 text-white/90 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+              <div className="panel-section-title">
+                <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                   <rect width="18" height="18" x="3" y="3" rx="2" />
                   <line x1="3" y1="21" x2="21" y2="3" />
                 </svg>
                 Layout
               </div>
               <div className="flex flex-col gap-2">
-                <label className="flex items-center gap-3 p-3 border-2 rounded-lg cursor-pointer transition-all bg-white border-gray-200 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50">
+                <label className="flex items-center gap-3 p-3 border-2 rounded-lg cursor-pointer transition-all bg-card border-border hover:border-primary/40 has-[:checked]:border-primary has-[:checked]:bg-accent">
                   <input
                     type="radio"
                     name="layout"
@@ -214,17 +218,17 @@ export default function CPDViewerPage() {
                     onChange={() => setLayoutMode('overlapping')}
                     className="sr-only"
                   />
-                  <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth={2} />
                     <circle cx="8" cy="16" r="2" fill="currentColor" />
                     <circle cx="16" cy="8" r="2" fill="currentColor" />
                   </svg>
                   <div>
-                    <div className="text-sm font-medium text-gray-700">Overlapping</div>
-                    <div className="text-xs text-gray-400">D1 and D2 on same axes</div>
+                    <div className="text-sm font-medium text-foreground">Overlapping</div>
+                    <div className="text-xs text-muted-foreground/70">D1 and D2 on same axes</div>
                   </div>
                 </label>
-                <label className="flex items-center gap-3 p-3 border-2 rounded-lg cursor-pointer transition-all bg-white border-gray-200 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50">
+                <label className="flex items-center gap-3 p-3 border-2 rounded-lg cursor-pointer transition-all bg-card border-border hover:border-primary/40 has-[:checked]:border-primary has-[:checked]:bg-accent">
                   <input
                     type="radio"
                     name="layout"
@@ -233,24 +237,24 @@ export default function CPDViewerPage() {
                     onChange={() => setLayoutMode('complementary')}
                     className="sr-only"
                   />
-                  <svg className="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <rect x="3" y="3" width="18" height="18" rx="2" strokeWidth={2} />
                     <line x1="3" y1="21" x2="21" y2="3" strokeWidth={2} />
                     <circle cx="8" cy="16" r="2" fill="currentColor" />
                     <circle cx="16" cy="8" r="2" fill="currentColor" />
                   </svg>
                   <div>
-                    <div className="text-sm font-medium text-gray-700">Complementary</div>
-                    <div className="text-xs text-gray-400">D1 mirrored below diagonal</div>
+                    <div className="text-sm font-medium text-foreground">Complementary</div>
+                    <div className="text-xs text-muted-foreground/70">D1 mirrored below diagonal</div>
                   </div>
                 </label>
               </div>
             </div>
 
             {/* Display Options Section */}
-            <div className="menu-section mb-6 pt-6 border-t-2 border-gray-300">
-              <div className="flex items-center gap-3 text-xs font-bold text-white -mx-5 mb-5 py-3.5 px-5 pl-[18px] bg-gradient-to-r from-blue-600 to-blue-500 uppercase tracking-wider shadow-sm">
-                <svg className="w-4 h-4 text-white/90 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <div className="menu-section mb-6 pt-6 border-t border-border">
+              <div className="panel-section-title">
+                <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                   <circle cx="12" cy="12" r="3" />
                   <path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
                 </svg>
@@ -262,21 +266,21 @@ export default function CPDViewerPage() {
                     type="checkbox"
                     checked={showGrid}
                     onChange={(e) => setShowGrid(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+                    className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                   />
-                  <span className="text-sm text-gray-600">Show Grid</span>
+                  <span className="text-sm text-muted-foreground">Show Grid</span>
                 </label>
                 {showGrid && (
                   <div className="flex items-center gap-2 ml-6">
-                    <span className="text-xs text-gray-400">Step:</span>
+                    <span className="text-xs text-muted-foreground/70">Step:</span>
                     {[5, 10, 20].map((step) => (
                       <button
                         key={step}
                         onClick={() => setGridStep(step)}
                         className={`px-2 py-1 text-xs border rounded transition-all ${
                           gridStep === step
-                            ? 'bg-blue-500 border-blue-500 text-white'
-                            : 'bg-white border-gray-200 text-gray-600 hover:bg-gray-50'
+                            ? 'bg-primary border-primary text-primary-foreground'
+                            : 'bg-card border-input text-muted-foreground hover:bg-accent'
                         }`}
                       >
                         {step}
@@ -289,80 +293,80 @@ export default function CPDViewerPage() {
                     type="checkbox"
                     checked={showDiagonal}
                     onChange={(e) => setShowDiagonal(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+                    className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                   />
-                  <span className="text-sm text-gray-600">Show Diagonal</span>
+                  <span className="text-sm text-muted-foreground">Show Diagonal</span>
                 </label>
                 <label className="flex items-center gap-2 cursor-pointer">
                   <input
                     type="checkbox"
                     checked={showFrame}
                     onChange={(e) => setShowFrame(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+                    className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                   />
-                  <span className="text-sm text-gray-600">Show Frame</span>
+                  <span className="text-sm text-muted-foreground">Show Frame</span>
                 </label>
               </div>
             </div>
 
             {/* Labels Section */}
-            <div className="menu-section mb-6 pt-6 border-t-2 border-gray-300">
-              <div className="flex items-center gap-3 text-xs font-bold text-white -mx-5 mb-5 py-3.5 px-5 pl-[18px] bg-gradient-to-r from-blue-600 to-blue-500 uppercase tracking-wider shadow-sm">
-                <svg className="w-4 h-4 text-white/90 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <div className="menu-section mb-6 pt-6 border-t border-border">
+              <div className="panel-section-title">
+                <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                   <path d="M4 7V4h16v3M9 20h6M12 4v16" />
                 </svg>
                 Labels
               </div>
               <div className="space-y-3">
                 <div>
-                  <label className="text-xs text-gray-500 uppercase tracking-wide">Title</label>
+                  <label className="panel-label">Title</label>
                   <input
                     type="text"
                     value={plotTitle}
                     onChange={(e) => setPlotTitle(e.target.value)}
                     placeholder="Plot title"
-                    className="w-full h-9 px-3 border border-gray-200 rounded text-sm mt-1"
+                    className="panel-input h-9 mt-1"
                   />
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Top</label>
+                    <label className="panel-label">Top</label>
                     <input
                       type="text"
                       value={labelTop}
                       onChange={(e) => setLabelTop(e.target.value)}
                       placeholder="Top"
-                      className="w-full h-9 px-3 border border-gray-200 rounded text-sm mt-1 placeholder:text-gray-300"
+                      className="panel-input h-9 mt-1"
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Bottom</label>
+                    <label className="panel-label">Bottom</label>
                     <input
                       type="text"
                       value={labelBottom}
                       onChange={(e) => setLabelBottom(e.target.value)}
                       placeholder="Bottom"
-                      className="w-full h-9 px-3 border border-gray-200 rounded text-sm mt-1 placeholder:text-gray-300"
+                      className="panel-input h-9 mt-1"
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Left</label>
+                    <label className="panel-label">Left</label>
                     <input
                       type="text"
                       value={labelLeft}
                       onChange={(e) => setLabelLeft(e.target.value)}
                       placeholder="Left"
-                      className="w-full h-9 px-3 border border-gray-200 rounded text-sm mt-1 placeholder:text-gray-300"
+                      className="panel-input h-9 mt-1"
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Right</label>
+                    <label className="panel-label">Right</label>
                     <input
                       type="text"
                       value={labelRight}
                       onChange={(e) => setLabelRight(e.target.value)}
                       placeholder="Right"
-                      className="w-full h-9 px-3 border border-gray-200 rounded text-sm mt-1 placeholder:text-gray-300"
+                      className="panel-input h-9 mt-1"
                     />
                   </div>
                 </div>
@@ -370,9 +374,9 @@ export default function CPDViewerPage() {
             </div>
 
             {/* Points Section */}
-            <div className="menu-section mb-6 pt-6 border-t-2 border-gray-300">
-              <div className="flex items-center gap-3 text-xs font-bold text-white -mx-5 mb-5 py-3.5 px-5 pl-[18px] bg-gradient-to-r from-blue-600 to-blue-500 uppercase tracking-wider shadow-sm">
-                <svg className="w-4 h-4 text-white/90 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <div className="menu-section mb-6 pt-6 border-t border-border">
+              <div className="panel-section-title">
+                <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                   <circle cx="12" cy="12" r="4" />
                   <circle cx="4" cy="4" r="2" />
                   <circle cx="20" cy="20" r="2" />
@@ -386,17 +390,17 @@ export default function CPDViewerPage() {
                     type="checkbox"
                     checked={sameColorscale}
                     onChange={(e) => setSameColorscale(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 text-blue-500 focus:ring-blue-500"
+                    className="h-4 w-4 rounded border-input text-primary focus:ring-ring"
                   />
-                  <span className="text-sm text-gray-600">Same colorscale for both</span>
+                  <span className="text-sm text-muted-foreground">Same colorscale for both</span>
                 </label>
                 {sameColorscale && (
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Shared Colorscale</label>
+                    <label className="panel-label">Shared Colorscale</label>
                     <select
                       value={sharedColorscale}
                       onChange={(e) => setSharedColorscale(e.target.value as ColorscaleName)}
-                      className="w-full h-9 px-3 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-9 mt-1"
                     >
                       {COLORSCALE_OPTIONS.map((cs) => (
                         <option key={cs} value={cs}>{cs}</option>
@@ -411,7 +415,7 @@ export default function CPDViewerPage() {
               </div>
 
               <div className="mb-3">
-                <label className="text-xs text-gray-500 uppercase tracking-wide">Point Size</label>
+                <label className="panel-label">Point Size</label>
                 <div className="flex items-center gap-3 mt-1">
                   <input
                     type="range"
@@ -421,33 +425,33 @@ export default function CPDViewerPage() {
                     onChange={(e) => setPointSize(parseInt(e.target.value))}
                     className="flex-1"
                   />
-                  <span className="text-sm text-gray-600 w-8">{pointSize}</span>
+                  <span className="text-sm text-muted-foreground w-8">{pointSize}</span>
                 </div>
               </div>
 
               {/* Upper Diagram Subsection */}
-              <div className="bg-gray-50 rounded-lg p-4 mb-4">
-                <div className="text-xs font-semibold text-gray-600 mb-3 flex items-center gap-1.5">
-                  <span className="w-2 h-2 rounded-sm bg-blue-800"></span>
+              <div className="bg-muted/50 rounded-lg p-4 mb-4">
+                <div className="text-xs font-semibold text-foreground mb-3 flex items-center gap-1.5">
+                  <span className="w-2 h-2 rounded-sm bg-primary"></span>
                   Upper Diagram (D₂)
                 </div>
                 <div className="space-y-2">
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Name</label>
+                    <label className="panel-label">Name</label>
                     <input
                       type="text"
                       value={upperName}
                       onChange={(e) => setUpperName(e.target.value)}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                   {!sameColorscale && (
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Colorscale</label>
+                      <label className="panel-label">Colorscale</label>
                       <select
                         value={upperColorscale}
                         onChange={(e) => setUpperColorscale(e.target.value as ColorscaleName)}
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       >
                         {COLORSCALE_OPTIONS.map((cs) => (
                           <option key={cs} value={cs}>{cs}</option>
@@ -460,11 +464,11 @@ export default function CPDViewerPage() {
                     </div>
                   )}
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Shape</label>
+                    <label className="panel-label">Shape</label>
                     <select
                       value={upperShape}
                       onChange={(e) => setUpperShape(e.target.value)}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     >
                       {MARKER_SHAPES.map((shape) => (
                         <option key={shape.value} value={shape.value}>{shape.label}</option>
@@ -473,50 +477,50 @@ export default function CPDViewerPage() {
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Multiplicity Min</label>
+                      <label className="panel-label">Multiplicity Min</label>
                       <input
                         type="number"
                         value={upperFilterMin}
                         onChange={(e) => setUpperFilterMin(e.target.value)}
                         placeholder="Min"
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Multiplicity Max</label>
+                      <label className="panel-label">Multiplicity Max</label>
                       <input
                         type="number"
                         value={upperFilterMax}
                         onChange={(e) => setUpperFilterMax(e.target.value)}
                         placeholder="Max"
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Lifetime Min</label>
+                      <label className="panel-label">Lifetime Min</label>
                       <input
                         type="number"
                         min="0"
                         value={upperLifetimeMin}
                         onChange={(e) => setUpperLifetimeMin(parseFloat(e.target.value) || 0)}
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Lifetime Max</label>
+                      <label className="panel-label">Lifetime Max</label>
                       <input
                         type="number"
                         min="0"
                         value={upperLifetimeMax}
                         onChange={(e) => setUpperLifetimeMax(parseFloat(e.target.value) || 0)}
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                   </div>
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Opacity</label>
+                    <label className="panel-label">Opacity</label>
                     <input
                       type="number"
                       min="0"
@@ -524,35 +528,35 @@ export default function CPDViewerPage() {
                       step="0.1"
                       value={upperOpacity}
                       onChange={(e) => setUpperOpacity(parseFloat(e.target.value))}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                 </div>
               </div>
 
               {/* Lower Diagram Subsection */}
-              <div className="bg-gray-50 rounded-lg p-4 mb-4">
-                <div className="text-xs font-semibold text-gray-600 mb-3 flex items-center gap-1.5">
+              <div className="bg-muted/50 rounded-lg p-4 mb-4">
+                <div className="text-xs font-semibold text-foreground mb-3 flex items-center gap-1.5">
                   <span className="w-2 h-2 rounded-sm bg-red-600"></span>
                   Lower Diagram (D₁)
                 </div>
                 <div className="space-y-2">
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Name</label>
+                    <label className="panel-label">Name</label>
                     <input
                       type="text"
                       value={lowerName}
                       onChange={(e) => setLowerName(e.target.value)}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                   {!sameColorscale && (
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Colorscale</label>
+                      <label className="panel-label">Colorscale</label>
                       <select
                         value={lowerColorscale}
                         onChange={(e) => setLowerColorscale(e.target.value as ColorscaleName)}
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       >
                         {COLORSCALE_OPTIONS.map((cs) => (
                           <option key={cs} value={cs}>{cs}</option>
@@ -565,11 +569,11 @@ export default function CPDViewerPage() {
                     </div>
                   )}
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Shape</label>
+                    <label className="panel-label">Shape</label>
                     <select
                       value={lowerShape}
                       onChange={(e) => setLowerShape(e.target.value)}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     >
                       {MARKER_SHAPES.map((shape) => (
                         <option key={shape.value} value={shape.value}>{shape.label}</option>
@@ -578,50 +582,50 @@ export default function CPDViewerPage() {
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Multiplicity Min</label>
+                      <label className="panel-label">Multiplicity Min</label>
                       <input
                         type="number"
                         value={lowerFilterMin}
                         onChange={(e) => setLowerFilterMin(e.target.value)}
                         placeholder="Min"
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Multiplicity Max</label>
+                      <label className="panel-label">Multiplicity Max</label>
                       <input
                         type="number"
                         value={lowerFilterMax}
                         onChange={(e) => setLowerFilterMax(e.target.value)}
                         placeholder="Max"
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Lifetime Min</label>
+                      <label className="panel-label">Lifetime Min</label>
                       <input
                         type="number"
                         min="0"
                         value={lowerLifetimeMin}
                         onChange={(e) => setLowerLifetimeMin(parseFloat(e.target.value) || 0)}
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                     <div>
-                      <label className="text-xs text-gray-500 uppercase tracking-wide">Lifetime Max</label>
+                      <label className="panel-label">Lifetime Max</label>
                       <input
                         type="number"
                         min="0"
                         value={lowerLifetimeMax}
                         onChange={(e) => setLowerLifetimeMax(parseFloat(e.target.value) || 0)}
-                        className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                        className="panel-input h-8 mt-1"
                       />
                     </div>
                   </div>
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Opacity</label>
+                    <label className="panel-label">Opacity</label>
                     <input
                       type="number"
                       min="0"
@@ -629,7 +633,7 @@ export default function CPDViewerPage() {
                       step="0.1"
                       value={lowerOpacity}
                       onChange={(e) => setLowerOpacity(parseFloat(e.target.value))}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                 </div>
@@ -637,9 +641,9 @@ export default function CPDViewerPage() {
             </div>
 
             {/* Connections Section */}
-            <div className="menu-section mb-6 pt-6 border-t-2 border-gray-300">
-              <div className="flex items-center gap-3 text-xs font-bold text-white -mx-5 mb-5 py-3.5 px-5 pl-[18px] bg-gradient-to-r from-blue-600 to-blue-500 uppercase tracking-wider shadow-sm">
-                <svg className="w-4 h-4 text-white/90 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <div className="menu-section mb-6 pt-6 border-t border-border">
+              <div className="panel-section-title">
+                <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                   <path d="M4 20L20 4" />
                   <circle cx="4" cy="20" r="2" />
                   <circle cx="20" cy="4" r="2" />
@@ -648,16 +652,16 @@ export default function CPDViewerPage() {
               </div>
               <div className="space-y-3">
                 <div>
-                  <label className="text-xs text-gray-500 uppercase tracking-wide">Name</label>
+                  <label className="panel-label">Name</label>
                   <input
                     type="text"
                     value={lineName}
                     onChange={(e) => setLineName(e.target.value)}
-                    className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                    className="panel-input h-8 mt-1"
                   />
                 </div>
                 <div>
-                  <label className="text-xs text-gray-500 uppercase tracking-wide">Color Mode</label>
+                  <label className="panel-label">Color Mode</label>
                   <div className="flex gap-2 mt-1">
                     <label className="flex items-center gap-1 cursor-pointer">
                       <input
@@ -668,7 +672,7 @@ export default function CPDViewerPage() {
                         onChange={() => setLineColorMode('scale')}
                         className="w-3 h-3"
                       />
-                      <span className="text-sm text-gray-600">Colorscale</span>
+                      <span className="text-sm text-muted-foreground">Colorscale</span>
                     </label>
                     <label className="flex items-center gap-1 cursor-pointer">
                       <input
@@ -679,13 +683,13 @@ export default function CPDViewerPage() {
                         onChange={() => setLineColorMode('single')}
                         className="w-3 h-3"
                       />
-                      <span className="text-sm text-gray-600">Single</span>
+                      <span className="text-sm text-muted-foreground">Single</span>
                     </label>
                   </div>
                 </div>
                 {lineColorMode === 'single' ? (
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Color</label>
+                    <label className="panel-label">Color</label>
                     <input
                       type="color"
                       value={lineSingleColor}
@@ -695,11 +699,11 @@ export default function CPDViewerPage() {
                   </div>
                 ) : (
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Colorscale</label>
+                    <label className="panel-label">Colorscale</label>
                     <select
                       value={lineColorscale}
                       onChange={(e) => setLineColorscale(e.target.value as ColorscaleName)}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     >
                       {COLORSCALE_OPTIONS.map((cs) => (
                         <option key={cs} value={cs}>{cs}</option>
@@ -713,29 +717,29 @@ export default function CPDViewerPage() {
                 )}
                 <div className="grid grid-cols-2 gap-2">
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Multiplicity Min</label>
+                    <label className="panel-label">Multiplicity Min</label>
                     <input
                       type="number"
                       value={lineFilterMin}
                       onChange={(e) => setLineFilterMin(e.target.value)}
                       placeholder="Min"
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Multiplicity Max</label>
+                    <label className="panel-label">Multiplicity Max</label>
                     <input
                       type="number"
                       value={lineFilterMax}
                       onChange={(e) => setLineFilterMax(e.target.value)}
                       placeholder="Max"
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Opacity</label>
+                    <label className="panel-label">Opacity</label>
                     <input
                       type="number"
                       min="0"
@@ -743,11 +747,11 @@ export default function CPDViewerPage() {
                       step="0.1"
                       value={lineOpacity}
                       onChange={(e) => setLineOpacity(parseFloat(e.target.value))}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                   <div>
-                    <label className="text-xs text-gray-500 uppercase tracking-wide">Width</label>
+                    <label className="panel-label">Width</label>
                     <input
                       type="number"
                       min="0.5"
@@ -755,7 +759,7 @@ export default function CPDViewerPage() {
                       step="0.5"
                       value={lineWidth}
                       onChange={(e) => setLineWidth(parseFloat(e.target.value))}
-                      className="w-full h-8 px-2 border border-gray-200 rounded text-sm mt-1"
+                      className="panel-input h-8 mt-1"
                     />
                   </div>
                 </div>
@@ -763,9 +767,9 @@ export default function CPDViewerPage() {
             </div>
 
             {/* Export Section */}
-            <div className="menu-section pt-6 border-t-2 border-gray-300">
-              <div className="flex items-center gap-3 text-xs font-bold text-white -mx-5 mb-5 py-3.5 px-5 pl-[18px] bg-gradient-to-r from-blue-600 to-blue-500 uppercase tracking-wider shadow-sm">
-                <svg className="w-4 h-4 text-white/90 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+            <div className="menu-section pt-6 border-t border-border">
+              <div className="panel-section-title">
+                <svg className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
                   <polyline points="7 10 12 15 17 10" />
                   <line x1="12" y1="15" x2="12" y2="3" />
@@ -775,13 +779,13 @@ export default function CPDViewerPage() {
               <div className="flex gap-2">
                 <button
                   onClick={handleExportSVG}
-                  className="flex-1 px-4 py-2 bg-white border border-gray-300 rounded text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+                  className="flex-1 px-4 py-2 bg-card border border-input rounded-md text-sm font-medium text-foreground hover:bg-accent transition-colors"
                 >
                   Export SVG
                 </button>
                 <button
                   onClick={handleExportPNG}
-                  className="flex-1 px-4 py-2 bg-blue-500 text-white rounded text-sm font-medium hover:bg-blue-600 transition-colors"
+                  className="flex-1 px-4 py-2 bg-primary text-primary-foreground rounded-md text-sm font-medium hover:bg-primary/90 transition-colors"
                 >
                   Export PNG
                 </button>
@@ -793,7 +797,7 @@ export default function CPDViewerPage() {
         <main
           className={`flex-1 p-5 transition-all duration-300 ${menuOpen ? 'ml-[340px]' : 'ml-0'}`}
         >
-          <div className="bg-white rounded-lg shadow p-5 h-[calc(100vh-120px)]">
+          <div className="figure-surface rounded-xl shadow-sm p-5 h-[calc(100vh-120px)]">
             <div ref={plotRef} className="w-full h-full">
               <Plot
                 divId="cpd-plot"

--- a/src/pages/CoursesPage.tsx
+++ b/src/pages/CoursesPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback, forwardRef, useImperativeHandle, useEffect } from 'react'
-import { Link } from 'react-router-dom'
 import { Switch } from '@/components/ui/switch'
-import { Home, TableProperties, LayoutGrid } from 'lucide-react'
+import { SiteHeader } from '@/components/SiteHeader'
+import { TableProperties, LayoutGrid } from 'lucide-react'
 import { AgGridReact } from 'ag-grid-react'
 import { AllCommunityModule, ModuleRegistry, ColDef, ICellRendererParams, CellStyle, IFilterParams, IDoesFilterPassParams } from 'ag-grid-community'
 import { visualizeLattice } from '@/lib/courses'
@@ -201,14 +201,14 @@ export default function CoursesPage() {
 
   const getTypeChipStyle = (type: string, isSelected: boolean) => {
     const colors: Record<string, { selected: string; dimmed: string }> = {
-      'A1': { selected: 'bg-blue-100 text-blue-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' },
-      'A2': { selected: 'bg-green-100 text-green-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' },
-      'A3': { selected: 'bg-yellow-100 text-yellow-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' },
-      'A4': { selected: 'bg-orange-100 text-orange-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' },
-      'A5': { selected: 'bg-red-100 text-red-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' },
-      'A6': { selected: 'bg-purple-100 text-purple-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' }
+      'A1': { selected: 'bg-blue-100 text-blue-800', dimmed: 'bg-muted text-muted-foreground/40' },
+      'A2': { selected: 'bg-green-100 text-green-800', dimmed: 'bg-muted text-muted-foreground/40' },
+      'A3': { selected: 'bg-yellow-100 text-yellow-800', dimmed: 'bg-muted text-muted-foreground/40' },
+      'A4': { selected: 'bg-orange-100 text-orange-800', dimmed: 'bg-muted text-muted-foreground/40' },
+      'A5': { selected: 'bg-red-100 text-red-800', dimmed: 'bg-muted text-muted-foreground/40' },
+      'A6': { selected: 'bg-purple-100 text-purple-800', dimmed: 'bg-muted text-muted-foreground/40' }
     }
-    const colorSet = colors[type] || { selected: 'bg-gray-100 text-gray-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' }
+    const colorSet = colors[type] || { selected: 'bg-gray-100 text-gray-800', dimmed: 'bg-muted text-muted-foreground/40' }
     return isSelected ? colorSet.selected : colorSet.dimmed
   }
 
@@ -226,11 +226,11 @@ export default function CoursesPage() {
 
   const getRemarkChipStyle = (remark: string, isSelected: boolean) => {
     const colors: Record<string, { selected: string; dimmed: string }> = {
-      'source-sink': { selected: 'bg-cyan-100 text-cyan-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' },
-      'corner-complete': { selected: 'bg-pink-100 text-pink-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' },
-      'new': { selected: 'bg-emerald-100 text-emerald-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' }
+      'source-sink': { selected: 'bg-cyan-100 text-cyan-800', dimmed: 'bg-muted text-muted-foreground/40' },
+      'corner-complete': { selected: 'bg-pink-100 text-pink-800', dimmed: 'bg-muted text-muted-foreground/40' },
+      'new': { selected: 'bg-emerald-100 text-emerald-800', dimmed: 'bg-muted text-muted-foreground/40' }
     }
-    const colorSet = colors[remark] || { selected: 'bg-gray-100 text-gray-800', dimmed: 'bg-gray-50 text-gray-300 opacity-50' }
+    const colorSet = colors[remark] || { selected: 'bg-gray-100 text-gray-800', dimmed: 'bg-muted text-muted-foreground/40' }
     return isSelected ? colorSet.selected : colorSet.dimmed
   }
 
@@ -245,11 +245,11 @@ export default function CoursesPage() {
 
   const renderFilterChips = () => {
     return (
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 px-6 py-4 mb-6">
+      <div className="bg-card rounded-xl shadow-sm border border-border px-6 py-4 mb-6">
         <div className="flex items-center gap-6 flex-wrap">
           {/* Type Filters */}
           <div className="flex items-center gap-2">
-            <span className="text-xs text-gray-500 font-medium">Type</span>
+            <span className="text-xs text-muted-foreground font-medium">Type</span>
             <div className="flex gap-1.5">
               {allTypes.map(type => (
                 <button
@@ -263,11 +263,11 @@ export default function CoursesPage() {
             </div>
           </div>
 
-          <div className="w-px h-6 bg-gray-200" />
+          <div className="w-px h-6 bg-border" />
 
           {/* Remark Filters */}
           <div className="flex items-center gap-2">
-            <span className="text-xs text-gray-500 font-medium">Remark</span>
+            <span className="text-xs text-muted-foreground font-medium">Remark</span>
             <div className="flex gap-1.5">
               {allRemarks.map(remark => (
                 <button
@@ -284,14 +284,14 @@ export default function CoursesPage() {
           {/* Reset button and count */}
           {hasFiltersChanged && (
             <>
-              <div className="w-px h-6 bg-gray-200" />
+              <div className="w-px h-6 bg-border" />
               <button
                 onClick={resetAllFilters}
-                className="text-xs text-gray-500 hover:text-gray-700 transition-colors"
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
                 Reset
               </button>
-              <span className="text-xs text-gray-400">
+              <span className="text-xs text-muted-foreground/70">
                 {filteredPaths.length}/{(plotData.paths as PathData[]).length}
               </span>
             </>
@@ -309,7 +309,7 @@ export default function CoursesPage() {
           return (
             <div
               key={index}
-              className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 hover:shadow-md transition-shadow"
+              className="figure-surface rounded-lg shadow-sm p-4 transition-shadow hover:shadow-md"
             >
               <div className="flex justify-between items-center mb-3">
                 <span className={`px-2.5 py-1 rounded-full text-xs font-semibold ${getTypeBadgeColor(data.type)}`}>
@@ -331,26 +331,40 @@ export default function CoursesPage() {
   }
 
   return (
-    <div className="min-h-screen">
-      <Link
-        to="/"
-        className="fixed top-4 left-4 p-2 bg-white rounded-lg hover:bg-gray-100 z-50 shadow-md"
-      >
-        <Home className="h-6 w-6" />
-      </Link>
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
 
-      <section className="py-16 px-4">
-        <div className="max-w-6xl mx-auto text-center">
-          <h1 className="text-3xl font-bold mb-8">Alternating Zigzag Courses for CL(4)</h1>
+      <main className="flex-1">
+        <section className="mx-auto max-w-6xl px-4 py-12 sm:px-6">
+          <div className="text-center">
+            <span className="section-eyebrow mb-3">Commutative Ladder CL(4)</span>
+            <h1 className="mb-3 text-3xl font-bold tracking-tight text-foreground">
+              Alternating Zigzag Courses
+            </h1>
+            <p className="mx-auto mb-8 max-w-xl text-sm text-muted-foreground">
+              Switch between the sortable table and the visual gallery, and filter by type or
+              remark.
+            </p>
 
-          <div className="flex items-center justify-center gap-4 mb-8">
-            <TableProperties className="h-6 w-6 text-blue-500" />
-            <Switch
-              checked={isGalleryView}
-              onCheckedChange={setIsGalleryView}
-              className="data-[state=checked]:bg-purple-600 data-[state=unchecked]:bg-blue-400"
-            />
-            <LayoutGrid className="h-6 w-6 text-purple-500" />
+            <div className="mb-10 inline-flex items-center gap-3 rounded-full border border-border bg-card px-4 py-2 shadow-sm">
+              <span
+                className={`inline-flex items-center gap-1.5 text-sm font-medium ${
+                  !isGalleryView ? 'text-foreground' : 'text-muted-foreground'
+                }`}
+              >
+                <TableProperties className="h-4 w-4" />
+                Table
+              </span>
+              <Switch checked={isGalleryView} onCheckedChange={setIsGalleryView} />
+              <span
+                className={`inline-flex items-center gap-1.5 text-sm font-medium ${
+                  isGalleryView ? 'text-foreground' : 'text-muted-foreground'
+                }`}
+              >
+                <LayoutGrid className="h-4 w-4" />
+                Gallery
+              </span>
+            </div>
           </div>
 
           {isGalleryView ? (
@@ -360,7 +374,10 @@ export default function CoursesPage() {
             </>
           ) : (
             <div className="flex justify-center">
-              <div className="ag-theme-alpine" style={{ height: 'calc(100vh - 200px)', width: '520px' }}>
+              <div
+                className="ag-theme-alpine figure-surface overflow-hidden rounded-xl p-2 shadow-sm"
+                style={{ height: 'calc(100vh - 280px)', width: '520px' }}
+              >
                 <AgGridReact<PathData>
                   rowData={plotData.paths as PathData[]}
                   columnDefs={columnDefs}
@@ -373,8 +390,8 @@ export default function CoursesPage() {
               </div>
             </div>
           )}
-        </div>
-      </section>
+        </section>
+      </main>
     </div>
   )
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
-import { Github, FileText } from 'lucide-react'
+import { SiteHeader } from '@/components/SiteHeader'
+import { SiteFooter } from '@/components/SiteFooter'
+import { Github, FileText, ArrowRight, Network, Grid3x3 } from 'lucide-react'
 
 const authors = [
   { name: 'Yasuaki Hiraoka', url: 'https://sites.google.com/site/yasuakihiraoka/' },
@@ -9,16 +11,49 @@ const authors = [
   { name: 'Chenguang Xu', url: null },
 ]
 
+const features = [
+  {
+    to: '/courses',
+    icon: Grid3x3,
+    title: 'Alternating Zigzag Courses',
+    description:
+      'Browse and filter the gallery of alternating zigzag courses for the commutative ladder CL(4), with interactive lattice diagrams.',
+    cta: 'Explore courses',
+  },
+  {
+    to: '/cpd-viewer',
+    icon: Network,
+    title: 'Connected Persistence Diagram Viewer',
+    description:
+      'Inspect connected persistence diagrams from the SiO₂ dataset used in the paper, with full control over layout, color, and connections.',
+    cta: 'Open viewer',
+  },
+]
+
 export default function HomePage() {
   return (
-    <div className="min-h-screen">
-      <section className="py-16 px-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold publication-title mb-8">
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+
+      <main className="flex-1">
+        {/* Hero */}
+        <section className="relative overflow-hidden border-b border-border">
+          <div
+            className="pointer-events-none absolute inset-0 opacity-[0.35] dark:opacity-25"
+            style={{
+              backgroundImage:
+                'radial-gradient(circle at 1px 1px, hsl(var(--muted-foreground)) 1px, transparent 0)',
+              backgroundSize: '32px 32px',
+            }}
+          />
+          <div className="relative mx-auto max-w-4xl px-4 py-20 text-center sm:px-6 sm:py-28">
+            <span className="section-eyebrow mb-6">
+              Topological Data Analysis
+            </span>
+            <h1 className="publication-title mb-6 text-4xl font-bold leading-tight text-foreground md:text-5xl">
               Refinement of Interval Approximations for Fully Commutative Quivers
             </h1>
-            <div className="text-lg publication-authors mb-8">
+            <div className="publication-authors mb-8 text-lg text-muted-foreground">
               {authors.map((author, index) => (
                 <span key={author.name} className="author-block">
                   {author.url ? (
@@ -32,83 +67,86 @@ export default function HomePage() {
                 </span>
               ))}
             </div>
-            <div className="flex flex-wrap justify-center gap-4">
-              <Button asChild variant="dark" className="rounded-full">
-                <a
-                  href="https://github.com/CommutativeGrids/commutazzio"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Github className="mr-2 h-4 w-4" />
-                  Code
-                </a>
-              </Button>
-              <Button asChild variant="dark" className="rounded-full">
+            <div className="flex flex-wrap justify-center gap-3">
+              <Button asChild className="rounded-full">
                 <a
                   href="https://link.springer.com/article/10.1007/s13160-025-00739-w"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
                   <FileText className="mr-2 h-4 w-4" />
-                  Paper
+                  Read the Paper
+                </a>
+              </Button>
+              <Button asChild variant="outline" className="rounded-full">
+                <a
+                  href="https://github.com/CommutativeGrids/commutazzio"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Github className="mr-2 h-4 w-4" />
+                  View Code
                 </a>
               </Button>
             </div>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section className="py-16 px-4 bg-gray-100">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold mb-6">Abstract</h2>
-          <div className="text-justify">
-            <p className="text-gray-700 leading-relaxed">
-              A fundamental difficulty in multiparameter persistent homology is the absence of a complete and discrete invariant.
-              To address this challenge, we propose an enhanced framework 
-              that not only achieves a holistic understanding of a fully commutative quiver's representation
-              via synthesizing interpretations obtained from intervals
-              but also can tune the balance between approximation resolution and computational complexity.
-              This framework is evaluated on commutative ladders of both finite-type and infinite-type.
-              In the former, we discover an efficient method for the indecomposable decomposition leveraging solely one-parameter persistent homology. 
-              In the latter, we introduce a new invariant that reveals partial persistence in the second parameter 
-              by connecting two standard persistence diagrams using interval approximations.
-              We then introduce several models for constructing commutative ladder filtrations,
-              offering new insights into random filtrations and 
-              demonstrating our toolkit's effectiveness by analyzing the topology of materials.
+        {/* Abstract */}
+        <section className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
+          <h2 className="section-eyebrow mb-4">Abstract</h2>
+          <p className="prose-abstract text-justify text-[1.05rem] leading-relaxed text-foreground/90">
+            A fundamental difficulty in multiparameter persistent homology is the absence of a
+            complete and discrete invariant. To address this challenge, we propose an enhanced
+            framework that not only achieves a holistic understanding of a fully commutative
+            quiver's representation via synthesizing interpretations obtained from intervals but
+            also can tune the balance between approximation resolution and computational
+            complexity. This framework is evaluated on commutative ladders of both finite-type and
+            infinite-type. In the former, we discover an efficient method for the indecomposable
+            decomposition leveraging solely one-parameter persistent homology. In the latter, we
+            introduce a new invariant that reveals partial persistence in the second parameter by
+            connecting two standard persistence diagrams using interval approximations. We then
+            introduce several models for constructing commutative ladder filtrations, offering new
+            insights into random filtrations and demonstrating our toolkit's effectiveness by
+            analyzing the topology of materials.
+          </p>
+        </section>
+
+        {/* Interactive tools */}
+        <section className="border-t border-border bg-muted/40">
+          <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6">
+            <h2 className="section-eyebrow mb-2">Interactive Tools</h2>
+            <p className="mb-10 text-2xl font-semibold tracking-tight text-foreground">
+              Explore the results
             </p>
+            <div className="grid gap-6 md:grid-cols-2">
+              {features.map((feature) => (
+                <Link
+                  key={feature.to}
+                  to={feature.to}
+                  className="group relative flex flex-col rounded-xl border border-border bg-card p-7 shadow-sm transition-all hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-md"
+                >
+                  <div className="mb-5 flex h-11 w-11 items-center justify-center rounded-lg bg-accent text-accent-foreground">
+                    <feature.icon className="h-5 w-5" />
+                  </div>
+                  <h3 className="mb-2 text-lg font-semibold text-foreground">
+                    {feature.title}
+                  </h3>
+                  <p className="mb-6 flex-1 text-sm leading-relaxed text-muted-foreground">
+                    {feature.description}
+                  </p>
+                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-primary">
+                    {feature.cta}
+                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                  </span>
+                </Link>
+              ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </main>
 
-      <section className="py-16 px-4">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold mb-6">
-            Gallery of alternating zigzag courses for CL(4)
-          </h2>
-          <div className="text-justify">
-            <p className="text-gray-700">
-              <Link to="/courses" className="text-blue-600 hover:underline">
-                See all the courses here.
-              </Link>
-            </p>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-16 px-4 bg-gray-100">
-        <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold mb-6">Connected Persistence Diagram Viewer</h2>
-          <div className="text-justify">
-            <p className="text-gray-700 mb-4">
-              Explore connected persistence diagrams from the SiO₂ dataset used in the paper.
-            </p>
-            <Button asChild variant="brand">
-              <Link to="/cpd-viewer">Open Viewer</Link>
-            </Button>
-          </div>
-        </div>
-      </section>
-
+      <SiteFooter />
     </div>
   )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,8 +13,8 @@ export default {
       },
       colors: {
         primary: {
-          DEFAULT: '#2563eb',
-          light: '#3b82f6',
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
         },
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary

Follow-up to #6 (the Connections legend fix, already merged). This PR contains the **whole-site visual redesign** that was committed after #6 was merged, so it needs its own PR.

A cohesive, modern-but-restrained scientific design system applied across all pages, with full light/dark mode:

- **Design tokens + dark mode** — refined palette in `index.css`, theme applied pre-paint via an inline script in `index.html` (no flash) and persisted through a header toggle (`src/lib/theme.ts`, `ui/theme-toggle.tsx`).
- **Shared chrome** — new `SiteHeader` (nav + Code/Paper links + theme toggle) and `SiteFooter` unify HomePage and CoursesPage; the CPD viewer keeps its app-shell layout but adopts the same tokens and gets the toggle.
- **Pages reworked** — HomePage (hero, serif abstract, tool cards), CoursesPage (themed chrome; grid/gallery/filter logic untouched), CPD Viewer (side panel restyled from the heavy blue gradient bars to a subtle scientific look).
- **Figures stay legible** — the Plotly diagram, lattice SVGs, and the data grid sit on a constant light "paper" surface in both themes, so the D3/Plotly rendering logic is left completely untouched.

No new dependencies; stays on Tailwind + shadcn/ui; all existing functionality preserved.

## Test plan

- [x] `tsc -b`, `eslint` (0 errors), and production `vite build` pass
- [x] Home / Courses (table + gallery) / CPD Viewer verified in both light and dark
- [x] Connections legend toggle and all CPD viewer controls confirmed still working after restyle
- [x] Courses grid + gallery filtering and Plotly export preserved
- [ ] Review the Netlify Deploy Preview for this PR before merging

https://claude.ai/code/session_01Ss3QHhdWWXGJEQVxvWvZLq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss3QHhdWWXGJEQVxvWvZLq)_