### PR TITLE
Apply header logo removal, menu-button fix, and shorter buttons (missed by PR #9)

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -15,8 +15,8 @@ export function SiteHeader({ leading }: { leading?: ReactNode }) {
 
   return (
     <header className="sticky top-0 z-50 border-b border-border bg-background">
+      {leading}
       <div className="mx-auto flex h-16 max-w-6xl items-center gap-4 px-4 sm:px-6">
-        {leading}
         <Link
           to="/"
           className="shrink-0 font-semibold tracking-tight text-foreground"

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -17,13 +17,11 @@ export function SiteHeader({ leading }: { leading?: ReactNode }) {
     <header className="sticky top-0 z-50 border-b border-border bg-background">
       <div className="mx-auto flex h-16 max-w-6xl items-center gap-4 px-4 sm:px-6">
         {leading}
-        <Link to="/" className="flex items-center gap-2.5 shrink-0">
-          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary text-primary-foreground font-bold">
-            Λ
-          </span>
-          <span className="hidden font-semibold tracking-tight text-foreground sm:inline">
-            Ladder Invariants
-          </span>
+        <Link
+          to="/"
+          className="shrink-0 font-semibold tracking-tight text-foreground"
+        >
+          Ladder Invariants
         </Link>
 
         <nav className="ml-2 flex items-center gap-1">

--- a/src/pages/CPDViewerPage.tsx
+++ b/src/pages/CPDViewerPage.tsx
@@ -161,7 +161,7 @@ export default function CPDViewerPage() {
           <button
             onClick={() => setMenuOpen(!menuOpen)}
             aria-label="Toggle controls"
-            className={`inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg transition-colors ${
+            className={`absolute left-3 top-1/2 z-10 -translate-y-1/2 inline-flex h-9 w-9 items-center justify-center rounded-lg transition-colors ${
               menuOpen ? 'bg-primary text-primary-foreground' : 'bg-transparent text-muted-foreground hover:bg-accent hover:text-foreground'
             }`}
           >

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -71,7 +71,7 @@ export default function HomePage() {
                   rel="noopener noreferrer"
                 >
                   <FileText className="mr-2 h-4 w-4" />
-                  Read the Paper
+                  Paper
                 </a>
               </Button>
               <Button asChild variant="outline" className="rounded-full">
@@ -81,7 +81,7 @@ export default function HomePage() {
                   rel="noopener noreferrer"
                 >
                   <Github className="mr-2 h-4 w-4" />
-                  View Code
+                  Code
                 </a>
               </Button>
             </div>


### PR DESCRIPTION
## Summary

Commits that were pushed to the branch **after PR #9's head was captured**, so PR #9 merged a stale head (`df29d62`) and these never reached `main`:

- **Remove the Λ logo mark** from the header — wordmark "Ladder Invariants" only (`482fab8`).
- **Pin the CPD viewer menu button** to the header's left edge so it doesn't shift the shared header's wordmark/nav (`a855373`).
- **Shorten hero buttons**: "Read the Paper" → "Paper", "View Code" → "Code" (`b5f8bf9`).

This is why the live site still showed the logo — the removal never made it into production.

## Test plan

- [x] `git grep Λ` returns nothing in `src/`, `index.html`, `public/`
- [x] Header wordmark sits at the same x-position on Home and CPD viewer (menu button no longer shifts it)
- [x] Hero buttons read "Paper" / "Code"

https://claude.ai/code/session_01Ss3QHhdWWXGJEQVxvWvZLq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss3QHhdWWXGJEQVxvWvZLq)_