### PR TITLE
Remove wordmark from header

### DIFF
--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -17,14 +17,7 @@ export function SiteHeader({ leading }: { leading?: ReactNode }) {
     <header className="sticky top-0 z-50 border-b border-border bg-background">
       {leading}
       <div className="mx-auto flex h-16 max-w-6xl items-center gap-4 px-4 sm:px-6">
-        <Link
-          to="/"
-          className="shrink-0 font-semibold tracking-tight text-foreground"
-        >
-          Ladder Invariants
-        </Link>
-
-        <nav className="ml-2 flex items-center gap-1">
+        <nav className="flex items-center gap-1">
           {navLinks.map((link) => {
             const active = pathname === link.to
             return (


### PR DESCRIPTION
## Summary

Remove the "Ladder Invariants" wordmark from the shared header. The header now leads with the nav (Overview / Courses / CPD Viewer); the **Overview** link still routes to home, so no navigation is lost.

## Test plan

- [x] Header no longer contains "Ladder Invariants" text (verified in DOM)
- [x] Nav + Code/Paper + theme toggle intact; CPD viewer menu button still left-pinned

https://claude.ai/code/session_01Ss3QHhdWWXGJEQVxvWvZLq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss3QHhdWWXGJEQVxvWvZLq)_